### PR TITLE
Added 'smoothing' option, to minimise flicker on estimated time remaining

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Revision history for Perl module Time::Progress
 
+1.11 2015-10-?? CADE
+  - Added 'smoothing' option which makes the estimated time remaining
+    monotically decreasing most of the time, preventing flicker.
+
 1.10 2015-08-23 CADE (changes from NEILB)
   - Removed redundant =cut at the end of the file, which was resulting
     in a pod warning.


### PR DESCRIPTION
Hi Vladi,

This is the feature I previously suggested in [RT#107162](https://rt.cpan.org/Public/Bug/Display.html?id=107162). It adds a 'smoothing' option, which can be specified as an option to the constructor.

If enabled, the estimated time left is naively smoothed, to reduce flicker, if you have `%e` or `%E` in your format string.

Cheers,
Neil
