### PR TITLE
Prevent potential div by zero when using smoothing

### DIFF
--- a/lib/Time/Progress.pm
+++ b/lib/Time/Progress.pm
@@ -111,7 +111,7 @@ sub report
       {
       $e = $l * ( $max - $min ) / ( $cur - $min );
       $e = int( $e - $l );
-      if ( $self->{ 'smoothing' } && defined( $last_e ) && $last_e < $e && ( ( $e - $last_e ) / $last_e ) < $sdelta )
+      if ( $self->{ 'smoothing' } && $last_e && $last_e < $e && ( ( $e - $last_e ) / $last_e ) < $sdelta )
         {
         $e = $last_e;
         }


### PR DESCRIPTION
In some circumstances when using smoothing you can trigger a division by zero.

The attached minimal patch fixes this.

I've not found a good way to produce a test case to reproduce I'm afraid...
